### PR TITLE
Fix deselectAllLayers issue in Sketch 45 by using Sketch API

### DIFF
--- a/Collapse Artboards And Groups.sketchplugin/Contents/Sketch/script.js
+++ b/Collapse Artboards And Groups.sketchplugin/Contents/Sketch/script.js
@@ -2,7 +2,8 @@ var onRun = function(context) {
   var doc = context.document
   var currentArtboard = doc.findCurrentArtboardGroup()
 
-  doc.currentPage().deselectAllLayers()
+  //deselect all layers
+  context.api().selectedDocument.selectedPage.selectedLayers.clear()
 
   var action = doc.actionsController().actionForID("MSCollapseAllGroupsAction")
 


### PR DESCRIPTION
Thanks for the plugin Dan.  

Here is a quick fix to make it compatible with Sketch 45.  I have tested this in Sketch 45, though not in previous versions.